### PR TITLE
Optimize collision using box2d

### DIFF
--- a/instance.py
+++ b/instance.py
@@ -1,0 +1,22 @@
+import pygame
+import ww
+import Box2D
+
+class Instance(pygame.sprite.Sprite):
+    def __init__(self, pos):
+        super().__init__()
+        pos = Box2D.b2Vec2(pos)
+        self.image = ww.images[self.__class__]
+        self.body = ww.world.CreateDynamicBody(position=pos / ww.PPM)
+        self.body.CreateFixture(ww.fixture_defs[self.__class__])
+        self.body.fixedRotation = True
+        self.body.userData = self
+        self.pos = pos
+        self.rect = self.image.get_rect(center=pos)
+
+    def update(self):
+        self.pos = self.body.transform.position * ww.PPM
+    
+    def kill(self):
+        ww.world.DestroyBody(self.body)
+        super().kill()

--- a/main.py
+++ b/main.py
@@ -6,19 +6,18 @@ from monster import *
 from player import Player
 from view import View
 from monster_constuctor import MonsterConstuctor
+from Box2D import *
 
-ww.player = Player((640,360), 120)
-ww.player_group = pygame.sprite.GroupSingle(ww.player)
-ww.group.add(ww.player_group)
+ww.group = pygame.sprite.LayeredUpdates()
+ww.player = Player((640,360))
+ww.group.add(ww.player)
 ww.view = View(target=ww.player, debug=True)
-ww.tree_group = pygame.sprite.Group()
-ww.monster_constuctor = MonsterConstuctor()
+ww.monster_constructor = MonsterConstuctor()
 
-for i in range(20):
+for i in range(50):
 	random_x = random.randint(0,1000)
 	random_y = random.randint(0,1000)
-	ww.tree_group.add(Tree((random_x, random_y)))
-ww.group.add(ww.tree_group)
+	ww.group.add(Tree((random_x, random_y)))
 
 while True:
 	for event in pygame.event.get():
@@ -29,8 +28,19 @@ while True:
 			if event.key == pygame.K_ESCAPE:
 				pygame.quit()
 				sys.exit()
-	ww.view.step()
-	ww.view.draw()
-	ww.monster_constuctor.update()
+
+	ww.monster_constructor.update()
+	ww.world.Step(1 / ww.FPS, 1, 1)
 	ww.group.update()
+	ww.view.update()
+	ww.view.draw()
 	pygame.display.update()
+	# ww.screen.fill('#71ddee')
+	# for sprite in ww.group.sprites():
+	# 	ww.group.change_layer(sprite, sprite.pos.y)
+	# ww.group.update()
+	# ww.group.draw(ww.screen)
+	# ww.view.update()
+	# ww.world.Step(1 / ww.FPS, 1, 1)
+	# pygame.display.update()
+	

--- a/monster/tree.py
+++ b/monster/tree.py
@@ -1,29 +1,19 @@
-import pygame
+from instance import Instance
 import ww
+from Box2D import *
 
-class Tree(pygame.sprite.Sprite):
+class Tree(Instance):
 	def __init__(self, pos):
-		super().__init__()
-		self.pos = pygame.Vector2(pos)
-		self.image = ww.Images.tree
-		self.rect = self.image.get_rect(topleft=pos)
-		self.speed = 1
+		super().__init__(pos)
+		self.speed = 5
 		self.mhp = 5
 		self.hp = self.mhp
 
 	def update(self):
+		super().update()
 		vel = ww.player.pos - self.pos
-		vel = vel.normalize() * self.speed
+		vel.Normalize()
+		self.body.linearVelocity = vel * self.speed
 
-		for x in ww.tree_group.sprites():
-			if x is self:
-				continue
-			if self.rect.colliderect(x.rect):
-				vel = pygame.math.Vector2(x.rect.center) - pygame.math.Vector2(self.rect.center)
-				vel = vel.normalize() * self.speed * -3
-				break
-
-		self.pos += vel
-		self.rect.center = self.pos
 		if self.hp == 0:
 			self.kill()

--- a/monster_constuctor.py
+++ b/monster_constuctor.py
@@ -1,7 +1,5 @@
-import pygame
 import ww
 from monster import *
-import random
 
 class MonsterConstuctor:
     def __init__(self):
@@ -9,11 +7,10 @@ class MonsterConstuctor:
         self.monster_list = ['Tree']
         self.pos = ww.view.rect.center
         self.construtor_time = 0
-        self.construtor_delay = 60
+        self.construtor_delay = 4
 
     def update(self):
         if self.construtor_time == self.construtor_delay:
-            ww.tree_group.add(Tree((0,0)))
-            ww.group.add(ww.tree_group)
+            ww.group.add(Tree((0,0)))
             self.construtor_time = 0
         self.construtor_time += 1

--- a/player.py
+++ b/player.py
@@ -1,32 +1,36 @@
 import pygame
+from instance import Instance
 import ww
 from bullet import Bullet
 
-class Player(pygame.sprite.Sprite):
-	def __init__(self, pos, health):
-		super().__init__()
-		self.health = health
-		self.image = ww.Images.player
-		self.pos = pos
-		self.rect = self.image.get_rect(center=pos)
-		self.direction = pygame.math.Vector2()
-		self.speed = 5
+class Player(Instance):
+	def __init__(self, pos):
+		super().__init__(pos)
+		self.speed = 25
+		self.mhp = 100
+		self.hp = self.mhp
 		self.attack_time = 0
-		self.attack_delay = 5
+		self.attack_delay = 4
 
 	def input(self):
 		keys = pygame.key.get_pressed()
 
-		self.direction.y = keys[pygame.K_s] - keys[pygame.K_w]
-		self.direction.x = keys[pygame.K_d] - keys[pygame.K_a]
+		self.direction = pygame.math.Vector2(
+			keys[pygame.K_d] - keys[pygame.K_a],
+			keys[pygame.K_s] - keys[pygame.K_w]
+		)
 			
 		if pygame.mouse.get_pressed()[0] and self.attack_time == 0:
-			ww.group.add(Bullet(self.rect.center, 20))
+			ww.group.add(Bullet(self.pos))
 			self.attack_time = self.attack_delay
 
 	def update(self):
+		super().update()
 		self.input()
-		self.pos += self.direction * self.speed
-		self.rect.center = self.pos
+		vel = self.direction
+		if vel:
+			vel.normalize_ip()
+		self.body.linearVelocity = vel * self.speed
+		
 		self.attack_time = max(self.attack_time - 1, 0)
-    		
+    	

--- a/view.py
+++ b/view.py
@@ -1,44 +1,58 @@
 import pygame
+from monster import *
 import ww
 
 class View:
 	def __init__(self, target=None, debug=False):
 		self.rect = pygame.Rect(0, 0, ww.SCREEN_WIDTH, ww.SCREEN_HEIGHT)
 		self.target = target
-		self.bg = ww.Images.view
-		self.bg_rect = self.bg.get_rect(topleft=(0, 0))
+		self.bg = ww.backgrounds['stage1']
+		self.bg_rect = self.bg.get_rect()
 		self.debug = debug
 		self.clock = pygame.time.Clock()
 		self.font = pygame.font.SysFont("Verdana", 20)
+		self.debug_text = []
 
-	def step(self):
+	def update(self):
 		if self.target:
-			self.rect.center = self.target.rect.center
+			self.rect.center = self.target.pos
+
+	def draw_debug_text(self):
+		for idx, text in enumerate(self.debug_text):
+			text = self.font.render(str(text), True, (0, 0, 0))
+			ww.screen.blit(text, (10, 10 + idx * 20))
+		self.debug_text.clear()
 
 	def draw(self):
 		ww.screen.fill('#71ddee')
-		clip_rect = self.bg_rect.clip(self.rect)
-		screen_rect = clip_rect.move(-self.rect.left, -self.rect.top)
-		inside_rect = clip_rect.move(-self.bg_rect.left, -self.bg_rect.top)
-		ww.screen.blit(self.bg, screen_rect, inside_rect)
+
+		screen_rect = self.bg_rect.move(-self.rect.left, -self.rect.top)
+		ww.screen.blit(self.bg, screen_rect)
+
+		for sprite in ww.group.sprites():
+			ww.group.change_layer(sprite, sprite.pos.y)
+			sprite.rect.center = sprite.pos - self.rect.topleft
 		
-		for sprite in sorted(ww.group, key=lambda sprite: sprite.rect.bottom):
-			clip_rect = sprite.rect.clip(self.rect)
-			screen_rect = clip_rect.move(-self.rect.left, -self.rect.top)
-			inside_rect = clip_rect.move(-sprite.rect.left, -sprite.rect.top)
-			ww.screen.blit(sprite.image, screen_rect, inside_rect)
+		ww.group.draw(ww.screen)
 		
-		for sprite in sorted(ww.tree_group, key=lambda sprite: sprite.rect.bottom):
-			hp_rect = pygame.Rect(sprite.rect.left, sprite.rect.bottom, sprite.rect.width, 10)
-			clip_rect = hp_rect.clip(self.rect)
-			pygame.draw.rect(ww.screen, (0, 0, 0), clip_rect.move(-self.rect.left, -self.rect.top), 0)
-			
-			border = ww.HP_BAR_BORDER
-			hp_rect = pygame.Rect(sprite.rect.left + border, sprite.rect.bottom + border,
-								  (sprite.rect.width - border * 2) * sprite.hp / sprite.mhp, 10 - border * 2)
-			clip_rect = hp_rect.clip(self.rect)
-			pygame.draw.rect(ww.screen, (255, 0, 0), clip_rect.move(-self.rect.left, -self.rect.top), 0)
+		for sprite in ww.group.sprites():
+			if isinstance(sprite, Tree):
+				hp_rect = pygame.Rect(sprite.rect.left, sprite.rect.bottom, sprite.rect.width, 8)
+				pygame.draw.rect(ww.screen, (0, 0, 0), hp_rect, 0, 5)
+				
+				border = ww.HP_BAR_BORDER
+				hp_rect = pygame.Rect(sprite.rect.left + border, sprite.rect.bottom + border,
+									(sprite.rect.width - border * 2) * sprite.hp / sprite.mhp, 8 - border * 2)
+				pygame.draw.rect(ww.screen, (255, 0, 0), hp_rect, 0, 5)
+
+		for body in ww.world.bodies:
+			for fixture in body.fixtures:
+				vertices = [body.transform * v * ww.PPM - self.rect.topleft for v in fixture.shape.vertices]
+				pygame.draw.polygon(ww.screen, (192, 32, 32), vertices, 2)
+				
 		
-		self.text = self.font.render(str(round(self.clock.get_fps(), 2)), True, (0, 0, 0))
-		ww.screen.blit(self.text, (10, 10))
-		self.clock.tick(60)
+		self.debug_text.append(round(self.clock.get_fps(), 2))
+		self.debug_text.append(len(ww.group))
+
+		self.draw_debug_text()
+		self.clock.tick(ww.FPS)

--- a/ww.py
+++ b/ww.py
@@ -1,16 +1,63 @@
+from enum import IntEnum
 import pygame
+from pygame.locals import *
+import Box2D
+import math
+from monster import *
+from player import Player
+from bullet import Bullet
 
-SCREEN_WIDTH = 1280
-SCREEN_HEIGHT = 720
+SCREEN_WIDTH = 1600
+SCREEN_HEIGHT = 900
 HP_BAR_BORDER = 2
+FPS = 60
+PPM = 20
 
 pygame.init()
 
-group = pygame.sprite.Group()
 screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+# screen = pygame.display.set_mode()
+# screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT), flags=OPENGL)
 
-class Images:
-    player = pygame.image.load('assets/player.png').convert_alpha()
-    tree = pygame.image.load('assets/tree.png').convert_alpha()
-    bullet = pygame.image.load('assets/bullet.png').convert_alpha()
-    view = pygame.image.load('assets/ground.png').convert_alpha()
+world = Box2D.b2World(gravity=(0, 0))
+
+images = {
+    Player: pygame.image.load('assets/player.png').convert_alpha(),
+    Tree: pygame.image.load('assets/tree.png').convert_alpha(),
+    Bullet: pygame.image.load('assets/bullet.png').convert_alpha()
+}
+
+backgrounds = {
+    'stage1': pygame.image.load('assets/ground.png').convert_alpha()
+}
+
+def _get_ellipsis_vertices(cls, pos, size):
+    precision = 16
+    vertices = []
+    rect_size = images[cls].get_rect().size if cls else (1, 1)
+    for i in range(precision):
+        angle = math.pi * 2 / precision * i
+        x = (math.cos(angle) * size[0] + pos[0]) * rect_size[0] / PPM
+        y = (math.sin(angle) * size[1] + pos[1]) * rect_size[1] / PPM
+        vertices.append(Box2D.b2Vec2(x, y))
+    return vertices
+
+class category_bits(IntEnum):
+    PLAYER  = 0b0000_0000_0000_0001
+    BULLET  = 0b0000_0000_0000_0010
+    MONSTER = 0b0000_0000_0000_0100
+
+fixture_defs = {
+    Player: Box2D.b2FixtureDef(
+        density=100.0, categoryBits=category_bits.PLAYER, maskBits=category_bits.MONSTER,
+        shape=Box2D.b2PolygonShape(vertices=_get_ellipsis_vertices(Player, (0, 0.3), (0.4, 0.2))),
+    ),
+    Tree: Box2D.b2FixtureDef(
+        density=0.1, categoryBits=category_bits.MONSTER, maskBits=category_bits.PLAYER | category_bits.MONSTER | category_bits.BULLET,
+        shape=Box2D.b2PolygonShape(vertices=_get_ellipsis_vertices(Tree, (0, 0.3), (0.4, 0.2))),
+    ),
+    Bullet: Box2D.b2FixtureDef(
+        density=0.1, categoryBits=category_bits.BULLET, maskBits=category_bits.MONSTER,
+        shape=Box2D.b2PolygonShape(vertices=_get_ellipsis_vertices(Bullet, (0, 0), (0.5, 0.5))),
+    ),
+}


### PR DESCRIPTION
box2d를 사용해서 충돌처리 부분을 고쳐보았습니다.

기존의 방식보다 훨씬 빠르게 충돌처리를 할 수 있기 때문에 적의 수가 약 70개체까지 늘어나더라도 60프레임을 유지합니다.

또한 원모양이나 8각형 등 다양한 정교한 충돌 범위를 지정할 수 있습니다.

![image](https://github.com/seokjin1013/wizard-of-the-forest-3/assets/130483717/635ed646-e628-4a00-b07d-523917a4b703)
